### PR TITLE
[Issue] Tag plugin rules doesn't include the plugin name

### DIFF
--- a/__tests__/core/rules.test.js
+++ b/__tests__/core/rules.test.js
@@ -13,14 +13,14 @@ describe('Rules', () => {
 
   test('Add empty rule', () => {
     expect(() => {
-      rules.add('', '', MockAdviserRule, {});
+      rules.add('', '', '', MockAdviserRule, {});
     }).toThrow(InvalidRuleError);
   });
 
   test('Add and get rule', () => {
     const ruleName = 'warning-min-test';
 
-    rules.add(ruleName, '', MockAdviserRule, {});
+    rules.add(ruleName, ruleName, '', MockAdviserRule, {});
     expect(rules.get(ruleName)).toBeDefined();
   });
 
@@ -28,7 +28,7 @@ describe('Rules', () => {
     const ruleName = 'warning-min-test';
 
     function add() {
-      rules.add(ruleName, '', null, {});
+      rules.add(ruleName, ruleName, '', null, {});
     }
 
     expect(add).toThrow(InvalidRuleError);
@@ -37,7 +37,7 @@ describe('Rules', () => {
 
   test('Get many rules', () => {
     for (let index = 0; index < 5; index++) {
-      rules.add(`warning-min-test-${index}`, 'plugin-name', MockAdviserRule, {});
+      rules.add(`warning-min-test-${index}`, `warning-min-test-${index}`, 'plugin-name', MockAdviserRule, {});
     }
 
     expect(Object.keys(rules.getAll()).length).toBe(5);
@@ -109,7 +109,7 @@ describe('Rules by Tags', () => {
     ];
 
     rawRules.forEach(rule => {
-      rules.add(rule.name, '', rule.core, {});
+      rules.add(rule.name, rule.name, '', rule.core, {});
     });
 
     expect(rules._getRulesFilteredByMetaTags(['fast']).length).toBe(1);
@@ -140,7 +140,7 @@ describe('Rules by Tags', () => {
     ];
 
     rawRules.forEach(rule => {
-      rules.add(rule.name, '', rule.core, {});
+      rules.add(rule.name, rule.name, '', rule.core, {});
     });
 
     expect(rules._getRulesFilteredBySettingTags(['fast'], { fast: ['warning-min-test-3'] }).length).toBe(1);
@@ -211,7 +211,7 @@ describe('Rules by Tags', () => {
     ];
 
     rawRules.forEach(rule => {
-      rules.add(rule.name, '', rule.core, {});
+      rules.add(rule.name, rule.name, '', rule.core, {});
     });
 
     expect(rules.getByTag(['diff', 'another', 'slow'], {}).length).toBe(2);
@@ -264,7 +264,7 @@ describe('Rules by Tags', () => {
     ];
 
     rawRules.forEach(rule => {
-      rules.add(rule.name, '', rule.core, {});
+      rules.add(rule.name, rule.name, '', rule.core, {});
     });
 
     expect(rules.getByTag(['fast'], { fast: ['warning-min-test-2'] }).length).toBe(1);

--- a/docusaurus/docs/available-arguments.md
+++ b/docusaurus/docs/available-arguments.md
@@ -92,7 +92,36 @@ Tags in the adviser configuration file will look like:
 
 Note: tags in the configuration file will override the tags defined in the rule's metatag
 
-To run the rules with tags `dependencies-change` and `fs` you will run: `adviser --tags dependencies-change,fs`
+To run the rules with tags `dependencies-change` and `fs` you will run:
+
+```
+adviser --tags dependencies-change,fs
+```
+
+Note: If the rule is within a external plugin, the full rule name is used. The below example shows the case.
+
+```
+{
+  "plugins":["dependencies"],
+  "rules": {
+    "package-json-properties": [
+      "error",
+      {
+        "required": ["private"],
+        "blacklist": ["license"]
+      }
+    ],
+    "dependencies/not-allowed-packages": ["error", { "packages": ["sec"] }],
+  },
+  "settings": {
+    "tags": {
+      "quick": ["package-json-properties", "dependencies/not-allowed-packages"],
+      "fs": ["rule1", "rule2"]
+    }
+  }
+}
+
+```
 
 ### Verbose
 

--- a/src/core/config/rules.js
+++ b/src/core/config/rules.js
@@ -32,7 +32,7 @@ class Rules {
    * @memberof Rules
    * @returns {Void}
    */
-  add(ruleId, pluginName, RuleCore, ruleSetting) {
+  add(ruleId, ruleFullName, pluginName, RuleCore, ruleSetting) {
     if (!ruleId || !RuleCore) {
       debug(`The rule with id ${ruleId} and core ${RuleCore} couldn't be added`);
       throw new InvalidRuleError(
@@ -44,7 +44,14 @@ class Rules {
 
     const normalizedSettings = this._normalizeSettings(ruleSetting);
 
-    const rule = new Rule(ruleId, pluginName, RuleCore, normalizedSettings.severity, normalizedSettings.options);
+    const rule = new Rule(
+      ruleId,
+      ruleFullName,
+      pluginName,
+      RuleCore,
+      normalizedSettings.severity,
+      normalizedSettings.options
+    );
 
     this._rules.push(rule);
 
@@ -134,7 +141,7 @@ class Rules {
       }
     });
 
-    return this._rules.filter(rule => ruleNames.includes(rule.id));
+    return this._rules.filter(rule => ruleNames.includes(rule.fullRuleName));
   }
 
   /**

--- a/src/core/engine.js
+++ b/src/core/engine.js
@@ -185,7 +185,7 @@ class Engine extends EventEmitter {
       const ruleSettings = configRules[fullRuleName];
 
       if (this.builtInRules[fullRuleName]) {
-        this.rules.add(fullRuleName, BUILT_IN_NAME, this.builtInRules[fullRuleName], ruleSettings);
+        this.rules.add(fullRuleName, fullRuleName, BUILT_IN_NAME, this.builtInRules[fullRuleName], ruleSettings);
       } else {
         const { pluginName, ruleName } = this._parseRawRuleName(fullRuleName);
 
@@ -202,7 +202,7 @@ class Engine extends EventEmitter {
             );
           }
 
-          this.rules.add(ruleName, pluginName, ruleCore, ruleSettings);
+          this.rules.add(ruleName, fullRuleName, pluginName, ruleCore, ruleSettings);
           plugin.addProcesedRule(this.rules.get(ruleName));
         } else {
           throw new InvalidRuleError(

--- a/src/core/rule/rule.js
+++ b/src/core/rule/rule.js
@@ -21,8 +21,9 @@ const SeverityEnum = require('../config/severity-enum');
  * @class Rule
  */
 class Rule {
-  constructor(id, pluginName, core, severity, options) {
+  constructor(id, fullRuleName, pluginName, core, severity, options) {
     this.id = id.toLowerCase();
+    this.fullRuleName = fullRuleName;
     this.pluginName = pluginName.toLowerCase();
 
     this.sharedContext = null;


### PR DESCRIPTION
Tagging rules in the configuration file doesn't work if the plugin name is included as the rules configuration.

In the below example `dependencies/not-allowed-packages` won't be picked up.

```
{
  "plugins":["dependencies"],
  "rules": {
    "package-json-properties": [
      "error",
      {
        "required": ["private"],
        "blacklist": ["license"]
      }
    ],
    "dependencies/not-allowed-packages": ["error", { "packages": ["sec"] }],
  },
  "settings": {
    "tags": {
      "quick": ["package-json-properties", "dependencies/not-allowed-packages"],
      "fs": ["rule1", "rule2"]
    }
  }
}
```

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Code style update
- [ ] Refactor (refactoring or adding test which isn't a fix or add a feature)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Did you test your solution?**

- [x] I lightly tested it
- [ ] I deeply tested it
- [x] I wrote tests around it (unit tests, integration tests, E2E tests)

## Solution Description

The filtering is done by full rule name instead of by rule id

## Side Effects, Risks, Impact

- [x] N/A

**Aditional comments:**
