### PR TITLE
Plugin hooks have access about the fs like rules

### DIFF
--- a/src/core/engine.js
+++ b/src/core/engine.js
@@ -75,7 +75,7 @@ class Engine extends EventEmitter {
       async.each(
         this.plugins.getAll(),
         (plugin, callback) => {
-          plugin.preRunHook(callback);
+          plugin.preRunHook(this.options.cwd, callback);
         },
         error => {
           if (error) {
@@ -133,7 +133,7 @@ class Engine extends EventEmitter {
       async.each(
         this.plugins.getAll(),
         (plugin, callback) => {
-          plugin.postRunHook(callback);
+          plugin.postRunHook(this.options.cwd, callback);
         },
         error => {
           if (error) {

--- a/src/core/plugin/plugin-context.js
+++ b/src/core/plugin/plugin-context.js
@@ -11,9 +11,12 @@
  * @class RuleContext
  */
 class PluginContext {
-  constructor(pluginName, rules) {
+  constructor(pluginName, dirname, rules) {
     this.pluginName = pluginName;
     this.rules = rules;
+    this.filesystem = {
+      dirname
+    };
 
     this._shared = {
       items: {}

--- a/src/core/plugin/plugin-summary.js
+++ b/src/core/plugin/plugin-summary.js
@@ -11,9 +11,12 @@
  * @class PluginSummary
  */
 class PluginSummary {
-  constructor(pluginName, rules) {
+  constructor(pluginName, dirname, rules) {
     this.pluginName = pluginName;
     this.rules = rules;
+    this.filesystem = {
+      dirname
+    };
 
     Object.freeze(this);
   }

--- a/src/core/plugin/plugin.js
+++ b/src/core/plugin/plugin.js
@@ -33,6 +33,7 @@ class Plugin {
       this.core = new Core(settings);
     } catch (error) {
       this.core = Core;
+      debug(`Error creating plugin ${id}`, error);
     }
 
     this.definedRules = this.core.rules;
@@ -47,7 +48,7 @@ class Plugin {
    * @returns
    * @memberof Plugin
    */
-  async preRunHook(asyncCallback) {
+  async preRunHook(currentDirectory, asyncCallback) {
     if (!this.core.preRun) {
       asyncCallback();
       return;
@@ -56,7 +57,7 @@ class Plugin {
     const contextRules = this.processedRules.map(rule => {
       return { id: rule.id, severity: rule.severity, options: rule.options };
     });
-    const context = new PluginContext(this.id, contextRules);
+    const context = new PluginContext(this.id, currentDirectory, contextRules);
 
     try {
       await this.core.preRun(context);
@@ -79,7 +80,7 @@ class Plugin {
    * @returns
    * @memberof Plugin
    */
-  async postRunHook(asyncCallback) {
+  async postRunHook(currentDirectory, asyncCallback) {
     if (!this.core.postRun) {
       asyncCallback();
       return;
@@ -93,7 +94,7 @@ class Plugin {
         duration: rule.executionDuration
       };
     });
-    const summary = new PluginSummary(this.id, summaryRules);
+    const summary = new PluginSummary(this.id, currentDirectory, summaryRules);
 
     try {
       await this.core.postRun(summary);


### PR DESCRIPTION
<!--
Please make sure to read the Contributing Guidelines: CONTRIBUTING.md
-->

<!--- Provide a general summary of your changes in the PR Title -->

Send filesystem information to plugin hooks during runtime.

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Code style update
- [ ] Refactor (refactoring or adding test which isn't a fix or add a feature)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Did you test your solution?**

- [x] I lightly tested it in one browser
- [ ] I deeply tested it in several browsers
- [ ] I wrote tests around it (unit tests, integration tests, E2E tests)

## Problem Description

The plugin hooks don't know where adviser is running.

## Solution Description

The adviser engine sends the filesystem information to the plugin hooks as it does to rules

## Side Effects, Risks, Impact

<!--- May your changes break other parts of the application? -->

- [x] No

**Aditional comments:**
